### PR TITLE
Update step counting on lines when using "-d"

### DIFF
--- a/source/display.d
+++ b/source/display.d
@@ -140,7 +140,7 @@ void display (Statement s, int indent)
 			}
 			if (!cur.statementListFalse.empty)
 			{
-				writef ("%4d:%-3d %-(%s%)", cur.statementListFalse[0].lineId-1, 2,
+				writef ("%4d:    %-(%s%)", cur.statementListFalse[0].lineId-1,
 				    "\t".repeat (indent));
 				writeln ("else:");
 				foreach (r; cur.statementListFalse)

--- a/source/display.d
+++ b/source/display.d
@@ -73,7 +73,7 @@ void display (Expression e)
 
 void display (Statement s, int indent)
 {
-	writef ("%4d:%-3d %-(%s%)", s.lineId, s.complexity,
+	writef ("%4d:%-3d %-(%s%)", s.lineId, s.complexity+1,
 	    "\t".repeat (indent));
 
 	{
@@ -140,7 +140,7 @@ void display (Statement s, int indent)
 			}
 			if (!cur.statementListFalse.empty)
 			{
-				writef ("    :   %-(%s%)",
+				writef ("%4d:%-3d %-(%s%)", cur.statementListFalse[0].lineId-1, 2,
 				    "\t".repeat (indent));
 				writeln ("else:");
 				foreach (r; cur.statementListFalse)
@@ -154,8 +154,8 @@ void display (Statement s, int indent)
 
 void displayFunction (FunctionBlock p)
 {
-	writefln ("%4d:    function %s (%-(%s, %)):",
-	    p.lineId, p.name, p.parameterList);
+	writefln ("%4d:%-3d function %s (%-(%s, %)):",
+	    p.lineId, p.parameterList.length, p.name, p.parameterList);
 	foreach (s; p.statementList)
 	{
 		display (s, 1);

--- a/source/display.d
+++ b/source/display.d
@@ -140,7 +140,7 @@ void display (Statement s, int indent)
 			}
 			if (!cur.statementListFalse.empty)
 			{
-				writef ("%4d:    %-(%s%)", cur.statementListFalse[0].lineId-1,
+				writef ("%4d:   %-(%s%)", cur.statementListFalse[0].lineId-1,
 				    "\t".repeat (indent));
 				writeln ("else:");
 				foreach (r; cur.statementListFalse)


### PR DESCRIPTION
Учитывая вопрос https://github.com/GassaFM/interpr/issues/30 о числе тактов, выдвигаю следующее предложение:
* Выводить на единицу больше на каждой строке, так как обработка строки занимает один такт
* Выводить число тактов для первой строки
* Выводить номер для строки с `else` (для однообразия)

Почему я считаю, что стоило бы сделать такое обновление? При использовании интерпретатора с командой `-d` хотелось бы уметь оценивать именно число `steps` для алгоритма, ведь оно и считается числом шагов выполнения программы.